### PR TITLE
Simplify binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Demonstrating the common patterns when using React, Redux v4, and TypeScript.
 
-Welcome to the Redux 4 + TypeScript 2.9 example! This example site shows you the ideal
+Welcome to the Redux 4 + TypeScript 3.3 example! This example site shows you the ideal
 project structure, recommended libraries, as well as design pattern on writing type-safe
 React + Redux app with TypeScript.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^16.8.4",
     "react-emotion": "^9.2.12",
     "react-redux": "^6.0.1",
+    "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.5",

--- a/src/pages/heroes/index.tsx
+++ b/src/pages/heroes/index.tsx
@@ -13,7 +13,7 @@ import LoadingSpinner from '../../components/data/LoadingSpinner'
 import { ApplicationState, ConnectedReduxProps } from '../../store'
 import { Hero } from '../../store/heroes/types'
 import { fetchRequest } from '../../store/heroes/actions'
-import { Dispatch } from 'redux';
+import { Dispatch } from 'redux'
 
 // Separate state props + dispatch props to their own interfaces.
 interface PropsFromState {
@@ -66,12 +66,11 @@ class HeroesIndexPage extends React.Component<AllProps> {
 
     return (
       <DataTable columns={['Hero', 'Pro Picks/Bans*', 'Pro Wins*']} widths={['auto', '', '']}>
-        {loading &&
-          data.length === 0 && (
-            <HeroLoading>
-              <td colSpan={3}>Loading...</td>
-            </HeroLoading>
-          )}
+        {loading && data.length === 0 && (
+          <HeroLoading>
+            <td colSpan={3}>Loading...</td>
+          </HeroLoading>
+        )}
         {data.map(hero => (
           <tr key={hero.id}>
             <HeroDetail>
@@ -102,9 +101,9 @@ const mapStateToProps = ({ heroes }: ApplicationState) => ({
 
 // mapDispatchToProps is especially useful for constraining our actions to the connected component.
 // You can access these via `this.props`.
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  fetchRequest: () => dispatch(fetchRequest())
-})
+const mapDispatchToProps = {
+  fetchRequest
+}
 
 // Now let's connect our component!
 // With redux v4's improved typings, we can finally omit generics here.

--- a/src/pages/heroes/show.tsx
+++ b/src/pages/heroes/show.tsx
@@ -14,7 +14,7 @@ import LoadingOverlayInner from '../../components/data/LoadingOverlayInner'
 import LoadingSpinner from '../../components/data/LoadingSpinner'
 import { darken } from 'polished'
 import { Themed } from 'react-emotion'
-import { Dispatch } from 'redux';
+import { Dispatch } from 'redux'
 
 // Separate state props + dispatch props to their own interfaces.
 interface PropsFromState {
@@ -121,9 +121,9 @@ const mapStateToProps = ({ heroes }: ApplicationState) => ({
 
 // mapDispatchToProps is especially useful for constraining our actions to the connected component.
 // You can access these via `this.props`.
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  fetchRequest: () => dispatch(fetchRequest())
-})
+const mapDispatchToProps = {
+  fetchRequest
+}
 
 // Now let's connect our component!
 // With redux v4's improved typings, we can finally omit generics here.

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -14,7 +14,7 @@ import LoadingSpinner from '../../components/data/LoadingSpinner'
 import { ApplicationState, ConnectedReduxProps } from '../../store'
 import { Team } from '../../store/teams/types'
 import { fetchRequest } from '../../store/teams/actions'
-import { Dispatch } from 'redux';
+import { Dispatch } from 'redux'
 
 // Separate state props + dispatch props to their own interfaces.
 interface PropsFromState {

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -109,9 +109,9 @@ const mapStateToProps = ({ teams }: ApplicationState) => ({
 
 // mapDispatchToProps is especially useful for constraining our actions to the connected component.
 // You can access these via `this.props`.
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  fetchRequest: () => dispatch(fetchRequest())
-})
+const mapDispatchToProps = {
+  fetchRequest
+}
 
 // Now let's connect our component!
 // With redux v4's improved typings, we can finally omit generics here.

--- a/src/pages/teams/show.tsx
+++ b/src/pages/teams/show.tsx
@@ -15,7 +15,7 @@ import { selectTeam, clearSelected } from '../../store/teams/actions'
 import { darken, transparentize } from '../../../node_modules/polished'
 import { Themed } from '../../../node_modules/react-emotion'
 import DataTable from '../../components/layout/DataTable'
-import { Dispatch } from 'redux';
+import { Dispatch } from 'redux'
 
 // Separate state props + dispatch props to their own interfaces.
 interface PropsFromState {
@@ -140,10 +140,10 @@ const mapStateToProps = ({ teams }: ApplicationState) => ({
 
 // mapDispatchToProps is especially useful for constraining our actions to the connected component.
 // You can access these via `this.props`.
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  selectTeam: (team_id: string) => dispatch(selectTeam(team_id)),
-  clearSelected: () => dispatch(clearSelected())
-})
+const mapDispatchToProps = {
+  selectTeam,
+  clearSelected
+}
 
 // Now let's connect our component!
 // With redux v4's improved typings, we can finally omit generics here.


### PR DESCRIPTION
Simplify the binding of ActionCreators by passing an object to mapDispatchToProps rather than a function as is recommended by Redux.